### PR TITLE
fixed image file name to push to heroku

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://www.zdnet.com/a/img/resize/55a3891b942ccec51db2d4b31b9278e7acc4bc72/2022/03/25/e09d2790-b5bb-4523-b8b2-c09d9b98b85b/unnamed.png?auto=webp&width=1200);">
   <div class="container">
-    <%= image_tag "logo", alt: "text", id: "hplogo"%>
+    <%= image_tag "logo.png", alt: "text", id: "hplogo"%>
     <h2>A Community Of Players Helping Players</h2>
     <div class="homesearch">
       <%= render "searchbar" %>


### PR DESCRIPTION
Heroku push requirement: when referring to file in asset, file format is needed. 
Ex: This will not work:
 `<%= image_tag "logo", alt: "text", id: "hplogo"%>`
This will work:
`<%= image_tag "logo.png", alt: "text", id: "hplogo"%>`

Added the ".png" to the end of the home page image tag logo